### PR TITLE
RFC: Drop the user and group identifiers from the docker build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,6 @@ $(TOOLS):
 	@echo "Building Docker container $@"
 	@docker build \
 		-t $(DOCKER_IMAGE_BASE)/$@:$(DOCKER_TAG) \
-		-t $(DOCKER_IMAGE_BASE)/$@:latest \
 		$(DOCKER_BUILD_ARGS) \
 		--build-arg BASE_IMAGE=$(OS_BASE):$(OS_VER) \
 		--build-arg RUNCMD="$@" \

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,8 @@ ORG_NAME := hihg-um
 OS_BASE ?= ubuntu
 OS_VER ?= 22.04
 
-USER ?= $$(USER)
-USERID ?= `id -u`
-USERGNAME ?= "adgc"
-USERGID ?= 5001
-
-IMAGE_REPOSITORY :=
-DOCKER_IMAGE_BASE := $(ORG_NAME)/$(USER)
+IMAGE_REPOSITORY ?=
+DOCKER_IMAGE_BASE := $(ORG_NAME)
 
 GIT_REV := $(shell git describe --tags --dirty)
 DOCKER_TAG ?= $(GIT_REV)
@@ -55,11 +50,6 @@ $(TOOLS):
 		-t $(DOCKER_IMAGE_BASE)/$@:latest \
 		$(DOCKER_BUILD_ARGS) \
 		--build-arg BASE_IMAGE=$(OS_BASE):$(OS_VER) \
-		--build-arg IMAGE_TOOLS="$(TOOLS)" \
-		--build-arg USERNAME=$(USER) \
-		--build-arg USERID=$(USERID) \
-		--build-arg USERGNAME=$(USERGNAME) \
-		--build-arg USERGID=$(USERGID) \
 		--build-arg RUNCMD="$@" \
 		.
 

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ DOCKER_TAG ?= $(GIT_REV)
 DOCKER_BUILD_ARGS :=
 
 TOOLS := bcftools plink2 samtools shapeit4 tabix vcftools
-SIF_IMAGES := $(TOOLS:=\:$(DOCKER_TAG).sif)
 DOCKER_IMAGES := $(TOOLS:=\:$(DOCKER_TAG))
+SIF_IMAGES := $(TOOLS:=\:$(DOCKER_TAG).sif)
 
-.PHONY: clean docker test $(TOOLS) $(DOCKER_IMAGES)
+.PHONY: clean docker test $(DOCKER_IMAGES) $(TOOLS)
 
 all: docker apptainer test
 


### PR DESCRIPTION
 - this eliminates per-user images for otherwise identical containers
 - the docker run --user parameter will substitute for this
 - security is not impacted because trivial hack-arounds remain, that are generally addressed by Apptainer