### PR TITLE
Additional label improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,17 +4,19 @@ FROM $BASE
 
 # build-args
 ARG BASE
-ARG BUILD_TIME
-ARG DOCKER_ARCH
 ARG GIT_TAG
 ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+ARG BUILD_TIME
+ARG URL_NAME
 
 LABEL org.opencontainers.image.authors="kms309@miami.edu,sxd1425@miami.edu"
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="$BASE"
 LABEL org.opencontainers.image.description="Base Image"
 LABEL org.opencontainers.image.created="$BUILD_TIME"
-LABEL org.opencontainers.image.url="ghcr.io/hihg-um/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${DOCKER_ARCH}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${URL_NAME}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
 LABEL org.opencontainers.image.source="https://github.com/hihg-um/docker-analytics"
 LABEL org.opencontainers.image.version="$GIT_TAG"
 LABEL org.opencontainers.image.revision="$GIT_REV"

--- a/Dockerfile.analytics
+++ b/Dockerfile.analytics
@@ -5,16 +5,16 @@ FROM $BASE
 # build-args
 ARG BASE
 ARG RUN_CMD
-ARG BUILD_TIME
-ARG DOCKER_ARCH
 ARG GIT_TAG
 ARG GIT_REV
+ARG BUILD_ARCH
+ARG BUILD_REPO
+ARG BUILD_TIME
 
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="$BASE"
 LABEL org.opencontainers.image.description="${RUN_CMD}"
-LABEL org.opencontainers.image.created="$BUILD_TIME"
-LABEL org.opencontainers.image.url="ghcr.io/hihg-um/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${DOCKER_ARCH}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
 
 # analytics package target - we want a new layer here, since different
 # dependencies will have to be installed, sharing the common base above

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ORG_NAME ?= hihg-um
 OS_BASE ?= ubuntu
 OS_VER ?= 24.04
 
-IMAGE_REPOSITORY ?=
+IMAGE_REPO ?= ghcr.io
 
 TOOLS := bcftools beagle plink1.9 plink2 samtools shapeit4 tabix vcftools
 
@@ -18,7 +18,7 @@ GIT_REPO_TAIL = $(patsubst docker-%,%,$(shell basename \
 GIT_SYNC ?= ($(shell git fetch 2>&1 && git diff @{upstream} 2>&1),)
 
 DOCKER_BUILD_OPTS ?= "--progress=plain"
-DOCKER_BUILD_TIME := "$(shell date)"
+DOCKER_BUILD_TIME := "$(shell date -u)"
 DOCKER_ARCH = $(shell uname -m)_$(shell uname -s | tr '[:upper:]' '[:lower:]')
 DOCKER_TAG ?= $(GIT_REV)_$(DOCKER_ARCH)
 
@@ -67,10 +67,11 @@ $(TOOLS):
 		-t $(ORG_NAME)/$@:$(DOCKER_TAG) \
 		--build-arg BASE=$(ORG_NAME)/$(GIT_REPO_TAIL):$(DOCKER_TAG) \
 		--build-arg RUN_CMD=$@ \
-		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
-		--build-arg DOCKER_ARCH=$(DOCKER_ARCH) \
 		--build-arg GIT_REV=$(GIT_REV) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
+		--build-arg BUILD_ARCH=$(DOCKER_ARCH) \
+		--build-arg BUILD_REPO=$(IMAGE_REPO)/$(ORG_NAME) \
+		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
 		.
 	$(if $(GIT_SYNC),, \
 		docker tag $(ORG_NAME)/$@:$(DOCKER_TAG) $(ORG_NAME)/$@:latest)
@@ -80,10 +81,12 @@ docker_base:
 	@docker build -t $(ORG_NAME)/$(GIT_REPO_TAIL):$(DOCKER_TAG) \
 		$(DOCKER_BUILD_OPTS) \
 		--build-arg BASE=$(OS_BASE):$(OS_VER) \
-		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
-		--build-arg DOCKER_ARCH=$(DOCKER_ARCH) \
 		--build-arg GIT_REV=$(GIT_REV) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
+		--build-arg BUILD_ARCH=$(DOCKER_ARCH) \
+		--build-arg BUILD_REPO=$(IMAGE_REPO)/$(ORG_NAME) \
+		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
+		--build-arg URL_NAME=$(GIT_REPO_TAIL) \
 		.
 
 docker_clean:
@@ -107,8 +110,8 @@ docker_test:
 docker_release:
 	@for f in $(GIT_REPO_TAIL):$(DOCKER_TAG) $(DOCKER_IMAGES); do \
 		docker tag $(ORG_NAME)/$$f \
-			$(IMAGE_REPOSITORY)/$(ORG_NAME)/$$f; \
-		docker push $(IMAGE_REPOSITORY)/$(ORG_NAME)/$$f; \
+			$(IMAGE_REPO)/$(ORG_NAME)/$$f; \
+		docker push $(IMAGE_REPO)/$(ORG_NAME)/$$f; \
 	done
 
 # Apptainer

--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,13 @@ DOCKER_TAG ?= $(GIT_REV)_$(DOCKER_ARCH)
 
 DOCKER_BASE= $(ORG_NAME)/$(GIT_REPO_TAIL):$(DOCKER_TAG)
 DOCKER_IMAGES := $(TOOLS:=\:$(DOCKER_TAG))
+DOCKER_IMAGES_TEST = $(DOCKER_IMAGES)
 SIF_IMAGES := $(TOOLS:=_$(DOCKER_TAG).sif)
 
 IMAGE_TEST := /test.sh
 
 .PHONY: apptainer_clean apptainer_distclean apptainer_test \
-	docker_base docker_clean docker_test docker_release $(TOOLS)
+	docker_base docker_clean docker_release $(TOOLS)
 
 help:
 	@echo "Targets: all build clean test release"
@@ -98,16 +99,14 @@ docker_clean:
 	done
 	@docker rmi -f $(DOCKER_BASE) 1> /dev/null 2>& 1
 
-docker_test:
-	@for f in $(DOCKER_IMAGES); do \
-		echo; echo "Testing Docker container: $(ORG_NAME)/$$f"; \
-		docker run -t \
-			-v /etc/passwd:/etc/passwd:ro \
-			-v /etc/group:/etc/group:ro \
-			--entrypoint=$(IMAGE_TEST) \
-			--user=$(shell echo `id -u`):$(shell echo `id -g`) \
-			$(ORG_NAME)/$$f; \
-	done
+$(DOCKER_IMAGES_TEST):
+	@echo
+	@echo "Testing Docker container: $(ORG_NAME)/$@"
+	@docker run -t \
+		--entrypoint=$(IMAGE_TEST) \
+		$(ORG_NAME)/$@
+
+docker_test: $(DOCKER_IMAGES_TEST)
 
 docker_release:
 	@for f in $(GIT_REPO_TAIL):$(DOCKER_TAG) $(DOCKER_IMAGES); do \

--- a/README.md
+++ b/README.md
@@ -9,8 +9,11 @@ This container packages several common analytics tools that
 are packaged by the Ubuntu Linux distribution maintainers:
 
  - bcftools
- - plink
+ - beagle
+ - plink1.9
  - plink2
  - samtools
+ - shapeit4
+ - tabix
  - vcftools
 

--- a/src/test/samtools.sh
+++ b/src/test/samtools.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-3.0
-samtools
+samtools version

--- a/src/test/shapeit4.sh
+++ b/src/test/shapeit4.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-3.0
-shapeit4
+shapeit4 --help

--- a/src/test/tabix.sh
+++ b/src/test/tabix.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # SPDX-License-Identifier: GPL-3.0
-tabix
+tabix --help


### PR DESCRIPTION
1. Label consistency and correctness fixes for HIHG containers
2. Add push workflow
3. Fix docker_test
4. factor out base image variable chain
5. update README
 - label build time is UTC
 - shorten repo name to IMAGE_REPO, pre-populate tentatively and pass it to the container build to construct a full URI
 - re-arrange parameters to maintain a clean name space
 - add a workflow for direct-pushes to main
 - docker test was not stopping if a build failed the test
 - reduce the chain of vars representing the base image to a single var
 - update list of produced containers / binaries