### PR TITLE
 Rework git tags, docker tags, labels and release

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,9 +15,12 @@ jobs:
     steps:
     - name: 'Checkout Actions'
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 5
+        fetch-tags: true
 
     - name: 'Build the Docker image'
-      run: make docker
+      run: IMAGE_REPO=ghcr.io make docker
 
     - name: 'Test the Docker image'
-      run: make docker_test
+      run: IMAGE_REPO=ghcr.io make docker_test

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: 'Checkout Actions'
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 5
+        fetch-tags: true
 
     - name: 'Login to GitHub Container Registry'
       uses: docker/login-action@v3
@@ -24,10 +27,10 @@ jobs:
         password: ${{secrets.GITHUB_TOKEN}}
 
     - name: 'Build the Docker image'
-      run: make docker
+      run: IMAGE_REPO="ghcr.io" make docker
 
     - name: 'Test the Docker image'
-      run: make docker_test
+      run: IMAGE_REPO="ghcr.io" make docker_test
 
     - name: 'Release the Docker image'
-      run: IMAGE_REPOSITORY=ghcr.io make docker_release
+      run: IMAGE_REPO="ghcr.io" make docker_release

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,25 @@ FROM $BASE
 
 # build-args
 ARG BASE
+ARG GIT_REPO
 ARG GIT_TAG
 ARG GIT_REV
-ARG BUILD_ARCH
 ARG BUILD_REPO
 ARG BUILD_TIME
-ARG URL_NAME
 
 LABEL org.opencontainers.image.authors="kms309@miami.edu,sxd1425@miami.edu"
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="$BASE"
-LABEL org.opencontainers.image.description="Base Image"
 LABEL org.opencontainers.image.created="$BUILD_TIME"
-LABEL org.opencontainers.image.url="${BUILD_REPO}/${URL_NAME}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
-LABEL org.opencontainers.image.source="https://github.com/hihg-um/docker-analytics"
-LABEL org.opencontainers.image.version="$GIT_TAG"
-LABEL org.opencontainers.image.revision="$GIT_REV"
-LABEL org.opencontainers.image.vendor="The Hussman Institute for Human Genomics, The University of Miami Miller School of Medicine"
+LABEL org.opencontainers.image.description="HIHG Base Image: Analytics"
 LABEL org.opencontainers.image.licenses="GPL-3.0"
+LABEL org.opencontainers.image.ref.name="Ubuntu Genomics Packages"
+LABEL org.opencontainers.image.revision="${GIT_REV}"
+LABEL org.opencontainers.image.source="https://${GIT_REPO}"
 LABEL org.opencontainers.image.title="Genomics Analysis Tools"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
+LABEL org.opencontainers.image.vendor="The Hussman Institute for Human Genomics, The University of Miami Miller School of Medicine"
+LABEL org.opencontainers.image.version="${GIT_TAG}"
 
 # Install OS updates, security fixes and utils, generic app dependencies
 RUN apt -y update -qq && apt -y upgrade && \

--- a/Dockerfile.analytics
+++ b/Dockerfile.analytics
@@ -5,16 +5,12 @@ FROM $BASE
 # build-args
 ARG BASE
 ARG RUN_CMD
-ARG GIT_TAG
-ARG GIT_REV
-ARG BUILD_ARCH
 ARG BUILD_REPO
-ARG BUILD_TIME
 
 LABEL org.opencontainers.image.base.digest=""
 LABEL org.opencontainers.image.base.name="$BASE"
-LABEL org.opencontainers.image.description="${RUN_CMD}"
-LABEL org.opencontainers.image.url="${BUILD_REPO}/${RUN_CMD}:${GIT_TAG}-${GIT_REV}_${BUILD_ARCH}"
+LABEL org.opencontainers.image.description="HIHG ${RUN_CMD}"
+LABEL org.opencontainers.image.url="${BUILD_REPO}"
 
 # analytics package target - we want a new layer here, since different
 # dependencies will have to be installed, sharing the common base above

--- a/Makefile
+++ b/Makefile
@@ -1,30 +1,46 @@
 # SPDX-License-Identifier: GPL-3.0
 
+IMAGE_REPO ?=
 ORG_NAME ?= hihg-um
 OS_BASE ?= ubuntu
 OS_VER ?= 24.04
 
-IMAGE_REPO ?= ghcr.io
-
 TOOLS := bcftools beagle plink1.9 plink2 samtools shapeit4 tabix vcftools
 
-GIT_TAG = $(shell git describe --tags --exact-match)
-GIT_REV = $(shell git describe --broken --dirty --all --long | \
-		sed "s,heads/,," | sed "s,tags/,," | \
-		sed "s,remotes/pull/.*/,," )
-GIT_REPO_TAIL = $(patsubst docker-%,%,$(shell basename \
-		`git remote --verbose | grep origin | grep fetch | \
-		cut -f2 | cut -d ' ' -f1` | sed 's/.git//'))
-GIT_SYNC ?= ($(shell git fetch 2>&1 && git diff @{upstream} 2>&1),)
+ifneq ($(IMAGE_REPO),)
+    DOCKER_REPO := $(IMAGE_REPO)/$(ORG_NAME)
+else
+    DOCKER_REPO := $(ORG_NAME)
+endif
 
-DOCKER_BUILD_OPTS ?= "--progress=plain"
-DOCKER_BUILD_TIME := "$(shell date -u)"
-DOCKER_ARCH = $(shell uname -m)_$(shell uname -s | tr '[:upper:]' '[:lower:]')
-DOCKER_TAG ?= $(GIT_REV)_$(DOCKER_ARCH)
+GIT_REPO := $(shell git remote get-url origin | sed 's,git@,,' | sed 's,:,/,')
+GIT_REPO_TAIL := $(shell basename $(GIT_REPO) | sed 's/.git//' | \
+			sed 's/docker-//')
+#GIT_SYNC ?= ($(shell git fetch 2>&1 && git diff @{upstream} 2>&1),)
+GIT_TAG_HEAD ?= $(shell git describe --exact-match --tags --dirty)
+GIT_TAG_LAST ?= $(shell git describe --abbrev=0 --tags)
 
-DOCKER_BASE= $(ORG_NAME)/$(GIT_REPO_TAIL):$(DOCKER_TAG)
+ifeq ($(GIT_TAG_HEAD),$(GIT_TAG_LAST))
+        GIT_LATEST := true
+        GIT_TAG := $(GIT_TAG_HEAD)
+        GIT_REV := $(shell git log -1 --pretty=format:%h)
+        DOCKER_TAG := $(GIT_TAG)
+else
+        GIT_TAG := $(GIT_TAG_LAST)
+        GIT_CNT := $(shell git rev-list $(GIT_TAG)..HEAD --count)
+        GIT_REV := $(shell git describe --broken --dirty --all --long | \
+			sed "s,heads/,," | sed "s,tags/,," | \
+			sed "s,remotes/pull/.*/,,")
+        DOCKER_TAG := $(GIT_REV)
+endif
+
+DOCKER_BASE := $(DOCKER_REPO)/$(GIT_REPO_TAIL):$(DOCKER_TAG)
 DOCKER_IMAGES := $(TOOLS:=\:$(DOCKER_TAG))
-DOCKER_IMAGES_TEST = $(DOCKER_IMAGES)
+DOCKER_IMAGES_TEST := $(DOCKER_IMAGES)
+
+DOCKER_BUILD_TIME := "$(shell date -u)"
+DOCKER_BUILD_OPTS ?= "--progress=plain"
+
 SIF_IMAGES := $(TOOLS:=_$(DOCKER_TAG).sif)
 
 IMAGE_TEST := /test.sh
@@ -38,14 +54,10 @@ help:
 	@echo "         apptainer apptainer_clean apptainer_distclean apptainer_test"
 	@echo
 	@echo "Docker container(s):"
-	@for f in $(DOCKER_IMAGES); do \
-		printf "\t$$f\n"; \
-	done
+	@for f in $(DOCKER_IMAGES); do printf "\t$$f\n"; done
 	@echo
 	@echo "Apptainer(s):"
-	@for f in $(SIF_IMAGES); do \
-		printf "\t$$f\n"; \
-	done
+	@for f in $(SIF_IMAGES); do printf "\t$$f\n"; done
 	@echo
 
 all: clean build test
@@ -62,58 +74,53 @@ test: docker_test apptainer_test
 docker: docker_base $(TOOLS)
 
 $(TOOLS):
-	@echo "Building Docker container: $(ORG_NAME)/$@:$(DOCKER_TAG)"
+	@echo "Building Docker container: $(DOCKER_REPO)/$@:$(DOCKER_TAG)"
 	@docker build \
 		$(DOCKER_BUILD_OPTS) \
 		-f Dockerfile.$(GIT_REPO_TAIL) \
-		-t $(ORG_NAME)/$@:$(DOCKER_TAG) \
+		-t $(DOCKER_REPO)/$@:$(DOCKER_TAG) \
 		--build-arg BASE=$(DOCKER_BASE) \
 		--build-arg RUN_CMD=$@ \
-		--build-arg GIT_REV=$(GIT_REV) \
-		--build-arg GIT_TAG=$(GIT_TAG) \
-		--build-arg BUILD_ARCH=$(DOCKER_ARCH) \
-		--build-arg BUILD_REPO=$(IMAGE_REPO)/$(ORG_NAME) \
-		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
+		--build-arg BUILD_REPO=$(DOCKER_REPO)/$@:$(DOCKER_TAG) \
 		.
-	$(if $(GIT_SYNC),, \
-		docker tag $(ORG_NAME)/$@:$(DOCKER_TAG) $(ORG_NAME)/$@:latest)
+	$(if $(GIT_LATEST), \
+		@docker tag \
+		$(DOCKER_REPO)/$@:$(DOCKER_TAG) $(DOCKER_REPO)/$@:latest)
 
 docker_base:
 	@echo "Building Docker base: $(DOCKER_BASE)"
 	@docker build -t $(DOCKER_BASE) \
 		$(DOCKER_BUILD_OPTS) \
 		--build-arg BASE=$(OS_BASE):$(OS_VER) \
+		--build-arg GIT_REPO=$(GIT_REPO) \
 		--build-arg GIT_REV=$(GIT_REV) \
 		--build-arg GIT_TAG=$(GIT_TAG) \
-		--build-arg BUILD_ARCH=$(DOCKER_ARCH) \
-		--build-arg BUILD_REPO=$(IMAGE_REPO)/$(ORG_NAME) \
+		--build-arg BUILD_REPO=$(DOCKER_BASE) \
 		--build-arg BUILD_TIME=$(DOCKER_BUILD_TIME) \
-		--build-arg URL_NAME=$(GIT_REPO_TAIL) \
 		.
 	@docker inspect $(DOCKER_BASE)
 
 docker_clean:
 	@docker builder prune -f 1> /dev/null 2>& 1
 	@for f in $(TOOLS); do \
-		docker rmi -f $(ORG_NAME)/$$f:$(DOCKER_TAG) 1> /dev/null 2>& 1; \
+		docker rmi -f $(DOCKER_REPO)/$$f:$(DOCKER_TAG) 1> /dev/null 2>& 1; \
 	done
 	@docker rmi -f $(DOCKER_BASE) 1> /dev/null 2>& 1
 
 $(DOCKER_IMAGES_TEST):
 	@echo
-	@echo "Testing Docker container: $(ORG_NAME)/$@"
+	@echo "Testing Docker container: $(DOCKER_REPO)/$@"
 	@docker run -t \
 		--entrypoint=$(IMAGE_TEST) \
-		$(ORG_NAME)/$@
+		$(DOCKER_REPO)/$@
 
 docker_test: $(DOCKER_IMAGES_TEST)
 
 docker_release:
-	@for f in $(GIT_REPO_TAIL):$(DOCKER_TAG) $(DOCKER_IMAGES); do \
-		docker tag $(ORG_NAME)/$$f \
-			$(IMAGE_REPO)/$(ORG_NAME)/$$f; \
-		docker push $(IMAGE_REPO)/$(ORG_NAME)/$$f; \
-	done
+	$(if $(GIT_LATEST), \
+		for f in $(GIT_REPO_TAIL):$(DOCKER_TAG) $(DOCKER_IMAGES); do \
+			docker push $(DOCKER_REPO)/$$f; done, \
+		$(info "Cannot push untagged build: $(GIT_TAG):$(GIT_REV)"))
 
 # Apptainer
 apptainer: $(SIF_IMAGES)
@@ -121,7 +128,7 @@ apptainer: $(SIF_IMAGES)
 $(SIF_IMAGES):
 	@for f in $(DOCKER_IMAGES); do \
 		echo "Building Apptainer: $@"; \
-		apptainer pull docker-daemon:$(ORG_NAME)/$$f; \
+		apptainer pull docker-daemon:$(DOCKER_REPO)/$$f; \
 	done
 
 apptainer_clean:


### PR DESCRIPTION
 - Only tagged builds can be released
 - Tagged builds are versioned / revisioned via tag name / short sha
 - Untagged builds are versiond via last tag / sha + diry
 - if IMAGE_REPO is non-empty, it is incorporated into the docker tag, only if a corresponding git tag exists and the code is clean