### PR TITLE
release_build fix

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -15,9 +15,6 @@ jobs:
     steps:
     - name: 'Checkout Actions'
       uses: actions/checkout@v4
-      with:
-        fetch-depth: 5
-        fetch-tags: true
 
     - name: 'Login to GitHub Container Registry'
       uses: docker/login-action@v3


### PR DESCRIPTION
 - Fix: "Error: fatal: Cannot fetch both ...3fe48ceaf and refs/tags/v0.2.12 to refs/tags/v0.2.12
 - If a tag is being pushed, the checkout directive with: fetch-tags: true causes this error
 - Since the release build is triggered by a tag, the checkout step "automagically" also clones tags, and the release build works without the with: fetch-tags, and fails per above with that directive
 - bit counter-intuitive, and seems to be a recent fix, that does not document this quirk