### PR TITLE
Tag fix

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
+    tags-ignore: ["*"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
image_build fix: ignore tags

     - when a tag is pushed, the same issue as fixed in d7644ac
       occurs, because the tag push also triggers an image build
       via the push trigger
     - it follows, that the image build should ignore tag pushes,
       since the tag push also builds it's own image, and thus
       the image-build workflow becomes unnecessary and redundant
     - we do this by telling the push trigger to ignore-tags